### PR TITLE
Remove Procfile and add manifest.yml

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: ./bin/grafana-server web

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,4 @@ applications:
   command: GF_SERVER_HTTP_PORT=$PORT GF_DATABASE_URL=$DATABASE_URL GF_DATABASE_SSL_MODE=require GF_SERVER_HTTP_ADDR=0.0.0.0 ./bin/grafana-server web
   buildpack: binary_buildpack
   services:
-- grafana_database
+    - grafana_database

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: grafana-paas
+  memory: 512M
+  instances: 1
+  command: GF_SERVER_HTTP_PORT=$PORT GF_DATABASE_URL=$DATABASE_URL GF_DATABASE_SSL_MODE=require GF_SERVER_HTTP_ADDR=0.0.0.0 ./bin/grafana-server web
+  buildpack: binary_buildpack
+  services:
+- grafana_database


### PR DESCRIPTION
We are able to specify more in the manifest.yml such as backing services
and the buildpack to be used.

This will also make it possible to deploy using Travis.