### PR TITLE
Configure grafana for logging in via google accounts

### DIFF
--- a/google_creds
+++ b/google_creds
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require "json"
+
+json = ENV.fetch("VCAP_SERVICES")
+vcap_services = JSON.parse(json)
+user_provided = vcap_services.fetch("user-provided")
+google_auth = user_provided.detect { |e| e["name"] == "google-auth" }
+
+raise "The google-auth user-provided service has not been set up." unless google_auth
+
+creds = google_auth.fetch("credentials")
+
+params = {
+  "GF_AUTH_GOOGLE_ENABLED" => true,
+  "GF_AUTH_GOOGLE_ALLOW_SIGN_UP" => true,
+  "GF_AUTH_GOOGLE_ALLOWED_DOMAINS" => "digital.cabinet-office.gov.uk",
+  "GF_AUTH_GOOGLE_CLIENT_ID" => creds.fetch("client_id"),
+  "GF_AUTH_GOOGLE_CLIENT_SECRET" => creds.fetch("secret"),
+}
+
+params.each { |k, v| print "#{k}=#{v} " }

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,8 @@ applications:
 - name: grafana-paas
   memory: 512M
   instances: 1
-  command: GF_SERVER_HTTP_PORT=$PORT GF_DATABASE_URL=$DATABASE_URL GF_DATABASE_SSL_MODE=require GF_SERVER_HTTP_ADDR=0.0.0.0 ./bin/grafana-server web
+  command: export `./google_creds` && GF_SERVER_ROOT_URL=https://grafana-paas.cloudapps.digital GF_SERVER_HTTP_PORT=$PORT GF_SERVER_HTTP_ADDR=0.0.0.0 GF_AUTH_DISABLE_LOGIN_FORM=true GF_DATABASE_URL=$DATABASE_URL GF_DATABASE_SSL_MODE=require ./bin/grafana-server web
   buildpack: binary_buildpack
   services:
     - grafana_database
+    - google-auth


### PR DESCRIPTION
IT set up an oauth profile. This configures grafana
to use the client_id and secret they provided.
We’ve set these as a user provided service in the
pass called ‘google-auth’:
https://docs.cloudfoundry.org/devguide/services/user-provided.html

We used environment variables for setting the
google auth configuration:
http://docs.grafana.org/installation/configuration/#auth-google