### PR TITLE
Upgrade grafana to 5.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 install:
-- wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.2.4.linux-amd64.tar.gz
-- tar -zxvf grafana-5.2.4.linux-amd64.tar.gz --strip-components=1
+- wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.3.2.linux-amd64.tar.gz
+- tar -zxvf grafana-5.3.2.linux-amd64.tar.gz --strip-components=1
 script:
 - whoami
 - pwd


### PR DESCRIPTION
Grafana 5.3 adds the ability to use template variables for filtering
tagged annotations.

Grafana 5.3.2 is the latest version, released on October 24.

https://github.com/grafana/grafana/blob/master/CHANGELOG.md#532-2018-10-24