### PR TITLE
bump grafana to 5.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 install:
-- wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.3.2.linux-amd64.tar.gz
-- tar -zxvf grafana-5.3.2.linux-amd64.tar.gz --strip-components=1
+- wget https://dl.grafana.com/oss/release/grafana-5.4.2.linux-amd64.tar.gz
+- tar -zxvf grafana-5.4.2.linux-amd64.tar.gz --strip-components=1
 script:
 - whoami
 - pwd


### PR DESCRIPTION
Release notes for 5.4.x:
https://community.grafana.com/t/release-notes-v5-4-x/12215

Not documented, but also important: the explore UI, which we enabled
in #8, now has a button to get to it, without needing to hack the URL.