### PR TITLE
upgrade to grafana 6.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 install:
-- wget https://dl.grafana.com/oss/release/grafana-5.4.2.linux-amd64.tar.gz
-- tar -zxvf grafana-5.4.2.linux-amd64.tar.gz --strip-components=1
+- wget https://dl.grafana.com/oss/release/grafana-6.1.3.linux-amd64.tar.gz
+- tar -zxvf grafana-6.1.3.linux-amd64.tar.gz --strip-components=1
 script:
 - whoami
 - pwd

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: grafana-paas
   memory: 512M
   instances: 1
-  command: export `./google_creds` && GF_EXPLORE_ENABLED=true GF_SERVER_ROOT_URL=https://grafana-paas.cloudapps.digital GF_SERVER_HTTP_PORT=$PORT GF_SERVER_HTTP_ADDR=0.0.0.0 GF_DATABASE_URL=$DATABASE_URL GF_DATABASE_SSL_MODE=require ./bin/grafana-server web
+  command: export `./google_creds` && GF_EXPLORE_ENABLED=true GF_SECURITY_COOKIE_SECURE=true GF_SESSION_COOKIE_SECURE=true GF_SERVER_ROOT_URL=https://grafana-paas.cloudapps.digital GF_SERVER_HTTP_PORT=$PORT GF_SERVER_HTTP_ADDR=0.0.0.0 GF_DATABASE_URL=$DATABASE_URL GF_DATABASE_SSL_MODE=require ./bin/grafana-server web
   buildpack: binary_buildpack
   services:
     - grafana-prod-db


### PR DESCRIPTION
I want to be able to [repeat panels for different datasources][1] which
is only available in grafana 6.1 or the as-yet-unreleased 5.4.4.

The upgrade notes for grafana 6 don't show anything scary:
https://grafana.com/docs/installation/upgrading/#upgrading-to-v6-0

As part of this, I have enabled cookie_secure in [session] and
[security] sections, because we only serve grafana over HTTPS.

[1]: https://github.com/grafana/grafana/issues/7492