### PR TITLE
fixes extraction of client_id/secret in alpine

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,8 +14,12 @@ applications:
     GF_SERVER_ROOT_URL: https://grafana-paas.cloudapps.digital
     GF_SERVER_HTTP_ADDR: "0.0.0.0"
     GF_DATABASE_SSL_MODE: "require"
-  command: |
-    export GF_AUTH_GOOGLE_CLIENT_ID=`echo $VCAP_SERVICES | grep -Po '"client_id": "\K[^"]*'` && export GF_AUTH_GOOGLE_CLIENT_SECRET=`echo $VCAP_SERVICES | grep -Po '"secret": "\K[^"]*'` && GF_SERVER_HTTP_PORT=$PORT GF_DATABASE_URL=$DATABASE_URL /run.sh
+  command: >
+    export GF_AUTH_GOOGLE_CLIENT_ID=`echo $VCAP_SERVICES | sed -E 's/.*"client_id":\s*"?([^"]*)"?.*/\1/'` &&
+    export GF_AUTH_GOOGLE_CLIENT_SECRET=`echo $VCAP_SERVICES | sed -E 's/.*"secret":\s*"?([^"]*)"?.*/\1/'` &&
+    export GF_SERVER_HTTP_PORT=$PORT &&
+    export GF_DATABASE_URL=$DATABASE_URL &&
+    /run.sh
   services:
     - grafana-prod-db
     - grafana-prometheus


### PR DESCRIPTION
## What

A recent Grafana upgrade appears to have switched the image to an alpine
base.

Alpine base only has the "diet" BusyBox version of tools like "grep"

the diet version of grep does not support the perl regex matching groups
and so was unable to extract the correct value from for the oauth client
id/secret from the big blob of JSON that is VCAP_SERVICES, causing the
authentication to be incorrectly setup.

This change switches to performing the task using sed, which while still
basically just as hacky as before, is able to perform the value
extraction required.

## Why

So that "login with google" works again when app is bound to something that provides VCAP_SERVICES with a `client_id` and `secret`