### PR TITLE
Upgrade to 7.0.5

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,75 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-07-06T09:54:24Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "manifest.yml": [
+      {
+        "hashed_secret": "da41b2fb3e47ce99e222cfef814a5fb5eac39069",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: grafana-paas
   docker:
-    image: grafana/grafana:6.7.4
+    image: grafana/grafana:7.0.5
   memory: 512M
   instances: 1
   env:


### PR DESCRIPTION
This does 2 things:

## add .secrets.baseline

generated with `detect-secrets scan > .secrets.baseline`

Based on guidance here:
https://github.com/alphagov/gds-pre-commit/blob/master/usage.md#check-in-your-secretsbaseline-file

It's part of this PR because my precommit hooks prevent me from committing if this file isn't present.

## upgrade to grafana 7.0.5

Release notes:
https://community.grafana.com/t/release-notes-v7-0-x/29381

There are breaking changes but I don't think any that should affect
us.