### PR TITLE
Provide DockerHub credentials to pull Grafana image

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,7 @@ applications:
 - name: grafana-paas
   docker:
     image: grafana/grafana:7.0.5
+    username: gdsobserve
   memory: 512M
   instances: 1
   env:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -32,3 +32,4 @@ jobs:
         params:
           manifest: grafana-paas-git/manifest.yml
           show_app_log: true
+          docker_password: ((dockerhub-password))


### PR DESCRIPTION
Since this runs a container from DockerHub on PaaS it might hit rate limit
issues soon. Try to pre-empt that by specifying credentials.