### PR TITLE
Update to Grafana 8.3.0

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: grafana-paas
   docker:
-    image: grafana/grafana:7.0.5
+    image: grafana/grafana:8.3.0
     username: gdsobserve
   memory: 512M
   instances: 1


### PR DESCRIPTION
### Context
The current version (7.0.5) of shared Grafana running on PaaS  is 18 months old.

This is a major version bump including various updates, improvements and security fixes.

See release notes here: https://grafana.com/docs/grafana/latest/release-notes/release-notes-8-3-0/

### Deployment & Migration

There appear to be no considerable breaking changes except credential storage for data sources (e.g. AWS CloudWatch IAM creds) which are currently stored unencrypted.

These must now be stored encrypted: https://grafana.com/docs/grafana/latest/installation/upgrading/#upgrading-to-v81

It's possible to migrate existing credentials by running the following command at deploy time:  

`grafana-cli admin data-migration encrypt-datasource-passwords`

It's recommended to create a PostgreSQL snapshot before upgrading.

### How To Review

Read release notes between versions 7.0.5 - 8.3.0 and consider any changes or deprecations that may affect tenants relying on such functionality: https://grafana.com/docs/grafana/latest/release-notes/


