### PR TITLE
Update Grafana to v8.3.1

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: grafana-paas
   docker:
-    image: grafana/grafana:8.3.0
+    image: grafana/grafana:8.3.1
     username: gdsobserve
   memory: 512M
   instances: 1


### PR DESCRIPTION
Contains a high severity security fix: https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/
